### PR TITLE
122016 fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,11 @@ platforms:
       box: bento/ubuntu-14.04
       box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.04_chef-provisionerless.box
 
+  - name: debian-8.6
+    driver:
+      box: bento/debian-8.6
+      box_url: https://atlas.hashicorp.com/bento/boxes/debian-8.6/versions/2.3.1/providers/vmware_desktop.box
+
   # CentOS 6.8
   - name: centos-6.8
     driver:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Valid values include:
 
 Specifies the New Relic license key to use.
 
+##### `proxy`
+
+Optional. Set the proxy server the agent should use. Examples:
+- `https://myproxy.foo.com:8080`
+- `http://10.10.254.254`
+
+##### `custom_attributes`
+
+Optional. A hash of custom attributes to annotate the data from this agent instance.
+
+##### `package_repo_ensure`
+
+Optional. A flag for omitting the New Relic package repo. Meant for environments where the `newrelic-infra`
+package has been mirrored to another repo that's already present on the system (set to `absent` to achieve this)
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ package has been mirrored to another repo that's already present on the system (
   - 14 Trusty
   - 12 Precise
 - Debian
-  - 10 Buster
-  - 9 Stretch
   - 8 Jessie
   - 7 Wheezy
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -68,10 +68,19 @@ class newrelic_infra::agent (
     notify  => Service['newrelic-infra'] # Restarts the agent service on config changes
   }
 
-  # Setup agent service
-  service { 'newrelic-infra':
-    ensure => 'running',
-    # provider => 'upstart', # may be required for your environment in CentOS 6
-    require => Package['newrelic-infra']
+  # we use Upstart on CentOS 6 systems and derivatives, which is not the default
+  if ($::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '6') 
+  or ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '2015') {
+    service { 'newrelic-infra':
+      ensure => 'running',
+      provider => 'upstart',
+      require => Package['newrelic-infra'],
+    }
+  } else {
+    # Setup agent service
+    service { 'newrelic-infra':
+      ensure => 'running',
+      require => Package['newrelic-infra'],
+    }
   }
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -7,6 +7,11 @@
 # [*license_key*]
 #   New Relic license key
 #
+# [*package_repo_ensure*]
+#   Optional flag to disable setting up New Relic's package repo.
+#   This is useful in the event the newrelic-infra package has been
+#   mirrored to a repo that already exists on the system
+#
 # === Authors
 #
 # New Relic, Inc.
@@ -14,6 +19,7 @@
 class newrelic_infra::agent (
   $ensure       = 'latest',
   $license_key  = '',
+  $package_repo_ensure  = 'present',
 ) {
   # Validate license key
   if $license_key == '' {
@@ -25,6 +31,7 @@ class newrelic_infra::agent (
   case $::operatingsystem {
     'Debian', 'Ubuntu': {
       apt::source { 'newrelic_infra-agent':
+        ensure       => $package_repo_ensure,
         location     => "https://download.newrelic.com/infrastructure_agent/linux/apt",
         release      => $lsbdistcodename,
         repos        => "main",
@@ -41,6 +48,7 @@ class newrelic_infra::agent (
     }
     'RedHat', 'CentOS','Amazon': {
       yumrepo { 'newrelic_infra-agent':
+        ensure        => $package_repo_ensure,
         descr         => "New Relic Infrastructure",
         baseurl       => "https://download.newrelic.com/infrastructure_agent/linux/yum/el/$operatingsystemmajrelease/x86_64",
         gpgkey        => "https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg",

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,7 +12,7 @@
 #   This is useful in the event the newrelic-infra package has been
 #   mirrored to a repo that already exists on the system
 #
-# [*package_repo_ensure*]
+# [*proxy*]
 #   Optional value for directing the agent to use a proxy in http(s)://domain.or.ip:port format
 #
 # [*custom_attributes*]

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -38,6 +38,9 @@ class newrelic_infra::agent (
   # Setup agent package repo
   case $::operatingsystem {
     'Debian', 'Ubuntu': {
+      package { 'apt-transport-https':
+        ensure => 'installed',
+      }
       apt::source { 'newrelic_infra-agent':
         ensure       => $package_repo_ensure,
         location     => "https://download.newrelic.com/infrastructure_agent/linux/apt",

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -14,6 +14,10 @@
 #
 # [*package_repo_ensure*]
 #   Optional value for directing the agent to use a proxy in http(s)://domain.or.ip:port format
+#
+# [*custom_attributes*]
+#   Optional hash of attributes to assign to this host (see docs https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#attributes)
+#
 # === Authors
 #
 # New Relic, Inc.
@@ -23,6 +27,7 @@ class newrelic_infra::agent (
   $license_key  = '',
   $package_repo_ensure  = 'present',
   $proxy = '',
+  $custom_attributes = {},
 ) {
   # Validate license key
   if $license_key == '' {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,6 +12,8 @@
 #   This is useful in the event the newrelic-infra package has been
 #   mirrored to a repo that already exists on the system
 #
+# [*package_repo_ensure*]
+#   Optional value for directing the agent to use a proxy in http(s)://domain.or.ip:port format
 # === Authors
 #
 # New Relic, Inc.
@@ -20,6 +22,7 @@ class newrelic_infra::agent (
   $ensure       = 'latest',
   $license_key  = '',
   $package_repo_ensure  = 'present',
+  $proxy = '',
 ) {
   # Validate license key
   if $license_key == '' {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "newrelic_infra",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "author": "New Relic, Inc.",
     "summary": "A Puppet module for installing New Relic Infrastructure Agent",
     "license": "https://github.com/newrelic/infrastructure-agent-puppet/LICENSE.md",

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
       {
         "operatingsystem": "Debian",
         "operatingsystemrelease": [
-          "7"
+          "7",
+          "8"
         ]
       },
       {

--- a/templates/newrelic-infra.yml.erb
+++ b/templates/newrelic-infra.yml.erb
@@ -1,3 +1,8 @@
 license_key: <%= @license_key %>
 
 proxy: <%= @proxy %>
+
+custom_attributes:
+<% @custom_attributes.each do |key,value|-%>
+    <%= key %>: <%= value%>
+<% end -%>

--- a/templates/newrelic-infra.yml.erb
+++ b/templates/newrelic-infra.yml.erb
@@ -1,1 +1,3 @@
 license_key: <%= @license_key %>
+
+proxy: <%= @proxy %>


### PR DESCRIPTION
This branch adds some capabilities to better cover the full spectrum of configuration possibilities, [as documented](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent)

It also fixes the following problems:
 * first-run failures resulting from [long-standing Puppet bug](https://tickets.puppetlabs.com/browse/MODULES-2190?)
 * failure to install on some deb/apt based machines that don't ship with `apt-transport-https` pre-installed
* inconsistencies in README/metadata [fixes #1]

All changes were tested locally using Kitchen.