### PR TITLE
Providing attributes display_name,verbose,log_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ Valid values include:
 
 Specifies the New Relic license key to use.
 
+##### `display_name`
+
+Optional. Override the auto-generated hostname for reporting.
+
+##### `verbose`
+
+Optional. Enables verbose logging for the agent when set the value with 1, the default value is 0.
+
+##### `log_file`
+
+Optional. To log to another location, provide a full path and file name. When not set, the agent logs to the system log files.
+Typical default locations:
+- Amazon Linux, CentOS, RHEL: `/var/log/messages`
+- Debian, Ubuntu: `/var/log/syslog`
+- Windows Server: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.log`
+
 ##### `proxy`
 
 Optional. Set the proxy server the agent should use. Examples:

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -15,6 +15,19 @@
 # [*proxy*]
 #   Optional value for directing the agent to use a proxy in http(s)://domain.or.ip:port format
 #
+# [*display_name*]
+#   Optional. Override the auto-generated hostname for reporting.
+#
+# [*verbose*]
+#   Optional. Enables verbose logging for the agent when set the value with 1, the default value is 0.
+#
+# [*log_file*]
+#   Optional. To log to another location, provide a full path and file name. When not set, the agent logs to the system log files.
+#   Typical default locations:
+#   - Amazon Linux, CentOS, RHEL: `/var/log/messages`
+#   - Debian, Ubuntu: `/var/log/syslog`
+#   - Windows Server: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.log`
+#
 # [*custom_attributes*]
 #   Optional hash of attributes to assign to this host (see docs https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#attributes)
 #

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -27,6 +27,9 @@ class newrelic_infra::agent (
   $license_key  = '',
   $package_repo_ensure  = 'present',
   $proxy = '',
+  $display_name = '',
+  $verbose = '',
+  $log_file = '',
   $custom_attributes = {},
 ) {
   # Validate license key
@@ -105,7 +108,7 @@ class newrelic_infra::agent (
   }
 
   # we use Upstart on CentOS 6 systems and derivatives, which is not the default
-  if ($::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '6') 
+  if ($::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '6')
   or ($::operatingsystem == 'Amazon') {
     service { 'newrelic-infra':
       ensure => 'running',

--- a/templates/newrelic-infra.yml.erb
+++ b/templates/newrelic-infra.yml.erb
@@ -2,6 +2,18 @@ license_key: <%= @license_key %>
 
 proxy: <%= @proxy %>
 
+<% unless @display_name.to_s.strip.empty? -%>
+display_name: <%= @display_name %>
+<% end -%>
+
+<% if @verbose =~ /[0-1]/  -%>
+verbose: <%= @verbose %>
+<% end -%>
+
+<% unless @log_file.to_s.strip.empty? -%>
+log_file: <%= @log_file %>
+<% end -%>
+
 custom_attributes:
 <% @custom_attributes.each do |key,value|-%>
     <%= key %>: <%= value%>


### PR DESCRIPTION
The attributes `display_name`,`verbose`,`log_file` could not be defined in the
previous version of the module as a parameter to the `newrelic_infra::agent` class. I’m following these configurations:
https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#all-links