### PR TITLE
Switch to ensure_packages to resolve the duplicate declaration of apt…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,7 @@ Pull requests should:
 By contributing to this project you agree that you are granting New Relic a non-exclusive, non-revokable, no-cost license to use the code, algorithms, patents, and ideas in that code in our products if we so choose. You also agree the code is provided as-is and you provide no warranties as to its fitness or correctness for any purpose
 
 Copyright (c) 2016 New Relic, Inc. All rights reserved.
+
+## Contributors
+
+* Phil McArdle (@philmcardle)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -54,9 +54,7 @@ class newrelic_infra::agent (
   # Setup agent package repo
   case $::operatingsystem {
     'Debian', 'Ubuntu': {
-      package { 'apt-transport-https':
-        ensure => 'installed',
-      }
+      ensure_packages('apt-transport-https')
       apt::source { 'newrelic_infra-agent':
         ensure       => $package_repo_ensure,
         location     => "https://download.newrelic.com/infrastructure_agent/linux/apt",

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,7 @@
       { "name": "puppet", "version_requirement": "3.x" }
     ],
     "dependencies": [
-      { "name": "puppetlabs-apt", "version_requirement": ">=2.3.0"}
+      { "name": "puppetlabs-apt", "version_requirement": ">=2.3.0"},
+      { "name": "puppetlabs-stdlib", "version_requirement": ">=4.2.0" }
     ]
 }


### PR DESCRIPTION
…-transport-https with other modules that also declare this.
Set expected dependency on puppetlabs-stdlib based on last major change to ensure_packages.

This is to resolve a duplicate declaration of apt-transport-https when including any other module that defines it (e.g. [vshn/gitlab](https://forge.puppet.com/vshn/gitlab))

> Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Duplicate declaration: Package[apt-transport-https] is already declared in file /etc/puppetlabs/.../modules/newrelic_infra/manifests/agent.pp:57; cannot redeclare at /etc/puppetlabs/.../modules/gitlab/manifests/install.pp:19:9 on node ...

This is my first change to a module, so I'm making best guesses about all changes here, but what research I did suggested ensure_packages was the best solution to this. I've set a dependency on puppetlabs-stdlib according to their last major change to this function.