### PR TITLE
Use "upstart" to manage service also on RHEL6 not only CentOS6

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -121,7 +121,7 @@ class newrelic_infra::agent (
   }
 
   # we use Upstart on CentOS 6 systems and derivatives, which is not the default
-  if ($::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '6')
+  if (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat')and $::operatingsystemmajrelease == '6')
   or ($::operatingsystem == 'Amazon') {
     service { 'newrelic-infra':
       ensure => 'running',


### PR DESCRIPTION
The script fails on RedHat Enterprise Linux 6 as it does not use upstart there to manage the service.
I've modified the "if"-condition to also use upstart on RHEL6 system, thus fixing the problem.