### PR TITLE
add service ensure

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,6 +4,9 @@
 # [*ensure*]
 #   Infrastructure agent version ('absent' will uninstall)
 #
+# [*service_ensure*]
+#   Infrastructure agent service status (default 'running')
+#
 # [*license_key*]
 #   New Relic license key
 #
@@ -36,14 +39,15 @@
 # New Relic, Inc.
 #
 class newrelic_infra::agent (
-  $ensure       = 'latest',
-  $license_key  = '',
+  $ensure               = 'latest',
+  $service_ensure       = 'running',
+  $license_key          = '',
   $package_repo_ensure  = 'present',
-  $proxy = '',
-  $display_name = '',
-  $verbose = '',
-  $log_file = '',
-  $custom_attributes = {},
+  $proxy                = '',
+  $display_name         = '',
+  $verbose              = '',
+  $log_file             = '',
+  $custom_attributes    = {},
 ) {
   # Validate license key
   if $license_key == '' {
@@ -124,14 +128,16 @@ class newrelic_infra::agent (
   if ($::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '6')
   or ($::operatingsystem == 'Amazon') {
     service { 'newrelic-infra':
-      ensure => 'running',
-      provider => 'upstart',
+      ensure  => $service_ensure,
+      start   => '/sbin/start newrelic-infra',
+      stop    => '/sbin/stop newrelic-infra',
+      status  => '/sbin/status newrelic-infra',
       require => Package['newrelic-infra'],
     }
   } else {
     # Setup agent service
     service { 'newrelic-infra':
-      ensure => 'running',
+      ensure => $service_ensure,
       require => Package['newrelic-infra'],
     }
   }


### PR DESCRIPTION
1. When using `provider => 'upstart'` we get the following error `Provider upstart is not functional on this host`.
2. add service_ensure to manage service status.