### PR TITLE
Change module name for autoload conformance

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "newrelic-infra",
+  "name": "newrelic-newrelic_infra",
   "version": "0.2.0",
   "author": "New Relic, Inc.",
   "summary": "A Puppet module for installing New Relic Infrastructure Agent",


### PR DESCRIPTION
Not sure how other people have been able to use this module, but since the class name is `newrelic_infra::agent`, Puppet will only look for it in a module named `newrelic_infra`.

See [here](https://puppet.com/docs/puppet/5.4/lang_namespaces.html#autoloader-behavior) for supporting documentation.

Another option would be to change the class name to `infra::agent`, but I find it less sensible.