### PR TITLE
Develop

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -86,10 +86,14 @@ class newrelic_infra::agent (
         require => Exec['newrelic_infra_apt_get_update'],
       }
     }
-    'RedHat', 'CentOS', 'Amazon': {
+    'RedHat', 'CentOS', 'Amazon', 'OracleLinux': {
       if ($::operatingsystem == 'Amazon') {
         $repo_releasever = '6'
-      } else {
+      } 
+      if ($::operatingsystem == 'OracleLinux') {
+        $repo_releasever = $::operatingsystemmajrelease
+      }
+        else {
         $repo_releasever = $::operatingsystemmajrelease
       }
       yumrepo { 'newrelic_infra-agent':

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -89,8 +89,7 @@ class newrelic_infra::agent (
     'RedHat', 'CentOS', 'Amazon', 'OracleLinux': {
       if ($::operatingsystem == 'Amazon') {
         $repo_releasever = '6'
-      } 
-      else {
+      } else {
         $repo_releasever = $::operatingsystemmajrelease
       }
       yumrepo { 'newrelic_infra-agent':

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -90,10 +90,7 @@ class newrelic_infra::agent (
       if ($::operatingsystem == 'Amazon') {
         $repo_releasever = '6'
       } 
-      if ($::operatingsystem == 'OracleLinux') {
-        $repo_releasever = $::operatingsystemmajrelease
-      }
-        else {
+      else {
         $repo_releasever = $::operatingsystemmajrelease
       }
       yumrepo { 'newrelic_infra-agent':


### PR DESCRIPTION
I have created this change, as we use OracleLinux here at WilliamHill.  Due to the facter ($::operatingsystem) call looking for a result of Redhat, Centos or Amazon Linux the agent was defaulting to the following even though OracleLinux is a RedHat family member.

fail('New Relic Infrastructure agent is not yet supported on this platform')

I have added OracleLinux to the agent.pp and tested. This resolves the issue for OracleLinux.

