### PR TITLE
Provide support for specifying custom configuration options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,4 @@ Use `bundle exec kitchen` to run commands.
 * Ruben Hervas (@xino12)
 * Nathan Smith (@smith)
 * Amir Yalon (@amiryal)
+* Irfan Patel (@irfanypatel)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Optional. Set the proxy server the agent should use. Examples:
 
 Optional. A hash of custom attributes to annotate the data from this agent instance.
 
+##### `custom_configs`
+
+Optional. A hash of agent configuration directives that are not exposed explicitly. Example:
+
+{'payload_compression' => 0, 'selinux_enable_semodule' => false}
+
 ##### `package_repo_ensure`
 
 Optional. A flag for omitting the New Relic package repo. Meant for environments where the `newrelic-infra`

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -34,6 +34,9 @@
 # [*custom_attributes*]
 #   Optional hash of attributes to assign to this host (see docs https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#attributes)
 #
+# [*custom_configs*]
+#   Optional. A hash of agent configuration directives that are not exposed explicitly. Example:
+#   {'payload_compression' => 0, 'selinux_enable_semodule' => false}
 # === Authors
 #
 # New Relic, Inc.
@@ -48,6 +51,7 @@ class newrelic_infra::agent (
   $verbose              = '',
   $log_file             = '',
   $custom_attributes    = {},
+  $custom_configs       = {},
 ) {
   # Validate license key
   if $license_key == '' {

--- a/templates/newrelic-infra.yml.erb
+++ b/templates/newrelic-infra.yml.erb
@@ -18,3 +18,5 @@ custom_attributes:
 <% @custom_attributes.each do |key,value|-%>
     <%= key %>: <%= value%>
 <% end -%>
+
+<%= @custom_configs.to_yaml.sub(/.*?\n/, '') %>


### PR DESCRIPTION
This PR addresses https://github.com/newrelic/infrastructure-agent-puppet/issues/27. To maintain backwards compatibilty, the use of a custom configurations hash to house config options that are not supported explicitly, has been chosen over the suggested approach of specifying a generic config hash for all options.