### PR TITLE
Specify correct version for puppet forge deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # newrelic-infra Puppet module CHANGELOG
 
+## 0.6.1 (2018-11-08)
+
+BUG FIXES:
+
+* Specify correct version in metadata.json
+
 ## 0.6.0 (2018-11-02)
 
 IMPROVEMENTS:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_infra",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "author": "New Relic, Inc.",
   "summary": "A Puppet module for installing New Relic Infrastructure Agent",
   "license":


### PR DESCRIPTION
I noticed that the deployment to puppet forge [was unsuccessful](https://api.travis-ci.org/v3/job/449734123/log.txt) because the version hadn't been bumped in metadata.json. This PR should address that, I've made it version 0.6.1 as it will need a new git tag. 

Feel free to fix this problem in a different way though :)