### PR TITLE
Select windows provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,4 @@ Use `bundle exec kitchen` to run commands.
 * Irfan Patel (@irfanypatel)
 * Alejandro Do Nascimento (@alejandrodnm)
 * Jonatan Bernal (@els-bernalj)
+* Keith Stone (@kwstone14)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -37,6 +37,12 @@
 # [*custom_configs*]
 #   Optional. A hash of agent configuration directives that are not exposed explicitly. Example:
 #   {'payload_compression' => 0, 'selinux_enable_semodule' => false}
+#
+# [*windows_provider*]
+#   Options. Allows for the selection of a provider other than 'windows' for the Windows MSI install. Or allows
+#   the windows provider to be used if another provider such as Chocolatey has been specified as the default
+#   provider in the puppet installation.
+#
 # === Authors
 #
 # New Relic, Inc.
@@ -52,6 +58,7 @@ class newrelic_infra::agent (
   $log_file             = '',
   $custom_attributes    = {},
   $custom_configs       = {},
+  $windows_provider     = 'windows',  
 ) {
   # Validate license key
   if $license_key == '' {
@@ -138,6 +145,7 @@ class newrelic_infra::agent (
         ensure => 'installed',
         source => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
         require => File['download_newrelic_agent'],
+        provider => $windows_provider,
       }
     }
     default: {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -58,7 +58,7 @@ class newrelic_infra::agent (
   $log_file             = '',
   $custom_attributes    = {},
   $custom_configs       = {},
-  $windows_provider     = 'windows',  
+  $windows_provider     = 'windows',
 ) {
   # Validate license key
   if $license_key == '' {
@@ -135,16 +135,16 @@ class newrelic_infra::agent (
     'windows': {
       # download the new relic infrastructure msi file
       file { 'download_newrelic_agent':
-        path => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
-        source => 'https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi',
         ensure => file,
+        path   => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
+        source => 'https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi',
       }
 
       package { 'newrelic-infra':
-        name => 'New Relic Infrastructure Agent',
-        ensure => 'installed',
-        source => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
-        require => File['download_newrelic_agent'],
+        ensure   => 'installed',
+        name     => 'New Relic Infrastructure Agent',
+        source   => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
+        require  => File['download_newrelic_agent'],
         provider => $windows_provider,
       }
     }
@@ -166,11 +166,11 @@ class newrelic_infra::agent (
   }
   else {
     file { 'newrelic_config_file':
-      name => 'C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml',
-      ensure => file,
+      ensure  => file,
+      name    => 'C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml',
       content => template('newrelic_infra/newrelic-infra.yml.erb'),
       require => Package['newrelic-infra'],
-      notify => Service['newrelic-infra'], # Restarts the agent service on config changes
+      notify  => Service['newrelic-infra'], # Restarts the agent service on config changes
     }
   }
 
@@ -178,9 +178,9 @@ class newrelic_infra::agent (
   if (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat')and $::operatingsystemmajrelease == '6')
   or ($::operatingsystem == 'Amazon') {
     service { 'newrelic-infra':
-      ensure  => $service_ensure,
+      ensure   => $service_ensure,
       provider => 'upstart',
-      require => Package['newrelic-infra'],
+      require  => Package['newrelic-infra'],
     }
   } elsif $::operatingsystem == 'SLES' {
     # Setup agent service for sysv-init service manager
@@ -199,4 +199,3 @@ class newrelic_infra::agent (
     }
   }
 }
-


### PR DESCRIPTION
… using a different default package provider for Windows in their puppet installations from 'windows' can "force" the windows provider to be used for this particular install.

Management at my company made a decision to make Chocolatey the default windows package provider. When I went to run this module against Windows servers, it failed due to not being able to find the newrelic-infra client with Chocolatey. Adding the windows_provider parameter with a default of 'windows' (which is what looks like is assumed anyway) made it possible to get the MSI installer while otherwise using Chocolatey as our default provider. If the windows package provider is the default for anyone else, they won't have to make any code changes in order to use the infrastructure-agent-puppet module.

This was useful to me. Perhaps it will be useful to other people, so I thought I'd put in a pull request and see if you think it will be helpful.

The contributing guidelines ask to provide tests. I'm not quite sure how to make a test for this, as it made the difference between the client installing and not. So if you have suggestions on what I should provide for tests, I can do it. I've deployed the Windows client to all of our servers using this fork. This is also my first time submitting a pull request on github.com, so any guidance on best practices will also be appreciated.