### PR TITLE
Adn/remove metapackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # newrelic-infra Puppet module CHANGELOG
 
+## 0.8.0
+
+IMPROVEMENTS:
+
+* Add support for installing individual integrations. The module switches from 
+  the deprecated `newrelic-infra-integrations` package (which only 
+  included 5 integrations), to the `nri-*` individual integration packages.
+
 ## 0.7.1 (2019-01-14)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 IMPROVEMENTS:
 
-* Add support for installing individual integrations. The module switches from 
-  the deprecated `newrelic-infra-integrations` package (which only 
+* Add support for installing individual integrations. The module switches from
+  the deprecated `newrelic-infra-integrations` package (which only
   included 5 integrations), to the `nri-*` individual integration packages.
 
 ## 0.7.1 (2019-01-14)
@@ -15,8 +15,8 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * Fix installation in Windows when the default provider for puppet was
-  set to something different than `windows`. Now the provider for 
-  installing the package can be specify with `windows_provider`, when 
+  set to something different than `windows`. Now the provider for
+  installing the package can be specify with `windows_provider`, when
   not set, it defaults to `windows`
 
 ## 0.7.0 (2018-11-16)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ class { 'newrelic_infra::integrations':
 
 The source code for each integration is available on [newrelic's github organization][4].
 
-#### On removing newrelic-infra-integrations package and its bundled integrations
+#### Removing newrelic-infra-integrations package and its bundled integrations
 
 **NOTE** *This only applies if you have the `newrelic-infra-integrations` 
 package installed*

--- a/manifests/integrations.pp
+++ b/manifests/integrations.pp
@@ -30,7 +30,7 @@ class newrelic_infra::integrations (
         subscribe   => Apt::Source['newrelic_infra-agent'],
         refreshonly => true,
       }
-      Exec['newrelic_infra_integrations_apt_get_update'] -> ensure_packages($integrations)
+      ensure_packages($integrations, { require => Exec['newrelic_infra_integrations_apt_get_update'] })
     }
     'RedHat', 'CentOS','Amazon': {
       if ($::operatingsystem == 'Amazon') {
@@ -46,7 +46,8 @@ class newrelic_infra::integrations (
         gpgcheck      => true,
         repo_gpgcheck => $repo_releasever != '5',
       }
-      ensure_packages($integrations) }
+      ensure_packages($integrations, { require => Yumrepo['newrelic_infra-integrations'] })
+    }
     'SLES': {
       # work around necessary because sles has a very old version of puppet and zypprepo can't not be installed
       exec { 'add_newrelic-integrations_repo':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_infra",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": "New Relic, Inc.",
   "summary": "A Puppet module for installing New Relic Infrastructure Agent",
   "license":

--- a/test/integration/default/init.pp
+++ b/test/integration/default/init.pp
@@ -2,4 +2,6 @@ class { 'newrelic_infra::agent':
   ensure      => 'latest',
   license_key => 'YOUR_NR_LICENSE_KEY',
 }
--> class { 'newrelic_infra::integrations': }
+-> class { 'newrelic_infra::integrations':
+  integrations => { 'nri-nginx' => { ensure => present } }
+}


### PR DESCRIPTION
Removes the use of the metapackage and adds the ability to install individual `nri-*` integration packages.

Fixes minor issues with SUSE.