### PR TITLE
A different approach for the custom_config hash

### DIFF
--- a/templates/newrelic-infra.yml.erb
+++ b/templates/newrelic-infra.yml.erb
@@ -19,4 +19,6 @@ custom_attributes:
     <%= key %>: <%= value%>
 <% end -%>
 
-<%= @custom_configs.to_yaml.sub(/.*?\n/, '') %>
+<% custom_configs.each do |key,value| -%>
+<%= key %>: <%= value %>
+<% end -%>


### PR DESCRIPTION
When I attempted to use the custom_config hash with my hieradata config, the resulting newrelic-infra.yml file had 2 leading spaces - which based on my tests caused the settings to be ignored.

My hieradata was:

```
newrelic_infra::agent::custom_configs:
  facter_interval_sec: 86400
  rpm_interval_sec: 86400
  selinux_interval_sec: 86400
  sysctl_interval_sec: 3600
```

And the newrelinc-infra.yml looked like:

```
custom_attributes:

  facter_interval_sec: 86400
  rpm_interval_sec: 86400
  selinux_interval_sec: 86400
  sysctl_interval_sec: 3600
```

The change proposed in this PR just leverages puppet's ability to loop through a hash - which seems based the comment in the agent.pp manifest is what we want to do.

```
# [*custom_configs*]
#   Optional. A hash of agent configuration directives that are not exposed explicitly. Example:
#   {'payload_compression' => 0, 'selinux_enable_semodule' => false}
```
