### PR TITLE
Fix puppet-lint errors in manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,4 @@ Use `bundle exec kitchen` to run commands.
 * Alejandro Do Nascimento (@alejandrodnm)
 * Jonatan Bernal (@els-bernalj)
 * Keith Stone (@kwstone14)
+* Josh Simmonds (@j0sh3rs)

--- a/manifests/integrations.pp
+++ b/manifests/integrations.pp
@@ -17,7 +17,7 @@ class newrelic_infra::integrations (
             command => "/usr/bin/zypper install -y ${integration_name}",
             path    => ['/usr/local/sbin', '/usr/local/bin', '/sbin', '/bin', '/usr/bin'],
             require => Exec['add_newrelic_integrations_repo'],
-            unless => "/bin/rpm -qa | /usr/bin/grep ${integration_name}"
+            unless  => "/bin/rpm -qa | /usr/bin/grep ${integration_name}"
           }
         }
         elsif $integrations[$integration_name]['ensure'] == 'absent' {


### PR DESCRIPTION
This PR addresses various puppet-lint warnings as of puppet-lint 2.3.6

```
modules/newrelic_infra/manifests/agent.pp - WARNING: arrow should be on the right operand's line on line 147
modules/newrelic_infra/manifests/agent.pp - WARNING: arrow should be on the right operand's line on line 151
modules/newrelic_infra/manifests/agent.pp - WARNING: arrow should be on the right operand's line on line 196
modules/newrelic_infra/manifests/agent.pp - WARNING: arrow should be on the right operand's line on line 215
modules/newrelic_infra/manifests/agent.pp - WARNING: case statement without a default case on line 91
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 29, but found it in column 28) on line 149
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 27, but found it in column 31) on line 161
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 27, but found it in column 31) on line 162
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 27, but found it in column 31) on line 163
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 27, but found it in column 26) on line 164
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 14, but found it in column 15) on line 279
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 14, but found it in column 15) on line 280
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 14, but found it in column 15) on line 281
modules/newrelic_infra/manifests/agent.pp - WARNING: indentation of => is not properly aligned (expected in column 14, but found it in column 15) on line 282
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 164
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 168
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 169
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 171
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 187
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 188
modules/newrelic_infra/manifests/agent.pp - WARNING: double quoted string containing no variables on line 194
modules/newrelic_infra/manifests/agent.pp - WARNING: variable not enclosed in {} on line 208
modules/newrelic_infra/manifests/integrations.pp - WARNING: indentation of => is not properly aligned (expected in column 21, but found it in column 20) on line 20
```

No other changes to the codebase except proper formatting.


Confirmed functional on puppet 3.8.5 in my environment. Alignment and quoting issues should have no bearing on other versions as well, by my understanding.