### PR TITLE
Define an optional parameter for temporary folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Optional. A hash of agent configuration directives that are not exposed explicit
  Optional. Allows for the selection of a provider other than 'windows' for the Windows MSI install. Or allows the windows provider to be used if another provider such as Chocolatey has been specified as the default provider in the puppet installation.
 
  ##### `windows_temp_folder`
-Optional. A string value for the temporary folder to download and install the MSI windows installation file. Exmaple:
+Optional. A string value for the temporary folder to download and install the MSI windows installation file. Example:
 
  ```
 windows_temp_folder => 'C:\\TEMP\\'

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ Optional. A hash of agent configuration directives that are not exposed explicit
 
 {'payload_compression' => 0, 'selinux_enable_semodule' => false}
 
+##### `windows_provider`
+
+ Optional. Allows for the selection of a provider other than 'windows' for the Windows MSI install. Or allows the windows provider to be used if another provider such as Chocolatey has been specified as the default provider in the puppet installation.
+
+ ##### `windows_temp_folder`
+Optional. A string value for the temporary folder to download and install the MSI windows installation file. Exmaple:
+
+ ```
+windows_temp_folder => 'C:\\TEMP\\'
+```
+
 ##### `package_repo_ensure`
 
 Optional. A flag for omitting the New Relic package repo. Meant for environments where the `newrelic-infra`

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Optional. A hash of agent configuration directives that are not exposed explicit
 Optional. A string value for the temporary folder to download and install the MSI windows installation file. Example:
 
  ```
-windows_temp_folder => 'C:\\TEMP\\'
+windows_temp_folder => 'C:/users/Administrator/Downloads'
 ```
 
 ##### `package_repo_ensure`

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -43,8 +43,10 @@
 #   Options. Allows for the selection of a provider other than 'windows' for the Windows MSI install. Or allows
 #   the windows provider to be used if another provider such as Chocolatey has been specified as the default
 #   provider in the puppet installation.
+#
 # [*windows_temp_folder*]
 #   Optional. A string value for the temporary folder to download and install the MSI windows installation file.
+#
 # [*linux_provider*]
 #   Specifies the provider to use for installing the agent. Two options are
 #   supported:
@@ -79,7 +81,7 @@ class newrelic_infra::agent (
   $custom_attributes    = {},
   $custom_configs       = {},
   $windows_provider     = 'windows',
-  $windows_temp_folder  = 'C:\\TEMP\\',
+  $windows_temp_folder  = 'C:/users/Administrator/Downloads',
   $linux_provider       = 'package_manager',
   $tarball_version      = undef
 ) {
@@ -233,14 +235,14 @@ class newrelic_infra::agent (
       # download the new relic infrastructure msi file
       file { 'download_newrelic_agent':
         ensure => file,
-        path   => "${windows_temp_folder}newrelic-infra.msi",
+        path   => "${windows_temp_folder}/newrelic-infra.msi",
         source => 'https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi',
       }
 
       package { 'newrelic-infra':
         ensure   => 'installed',
         name     => 'New Relic Infrastructure Agent',
-        source   => "${windows_temp_folder}newrelic-infra.msi",
+        source   => "${windows_temp_folder}/newrelic-infra.msi",
         require  => File['download_newrelic_agent'],
         provider => $windows_provider,
       }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -43,7 +43,8 @@
 #   Options. Allows for the selection of a provider other than 'windows' for the Windows MSI install. Or allows
 #   the windows provider to be used if another provider such as Chocolatey has been specified as the default
 #   provider in the puppet installation.
-
+# [*windows_temp_folder*]
+#   Optional. A string value for the temporary folder to download and install the MSI windows installation file.
 # [*linux_provider*]
 #   Specifies the provider to use for installing the agent. Two options are
 #   supported:
@@ -78,6 +79,7 @@ class newrelic_infra::agent (
   $custom_attributes    = {},
   $custom_configs       = {},
   $windows_provider     = 'windows',
+  $windows_temp_folder  = 'C:\\TEMP\\',
   $linux_provider       = 'package_manager',
   $tarball_version      = undef
 ) {
@@ -231,14 +233,14 @@ class newrelic_infra::agent (
       # download the new relic infrastructure msi file
       file { 'download_newrelic_agent':
         ensure => file,
-        path   => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
+        path   => "${windows_temp_folder}newrelic-infra.msi",
         source => 'https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi',
       }
 
       package { 'newrelic-infra':
         ensure   => 'installed',
         name     => 'New Relic Infrastructure Agent',
-        source   => 'C:\users\Administrator\Downloads\newrelic-infra.msi',
+        source   => "${windows_temp_folder}newrelic-infra.msi",
         require  => File['download_newrelic_agent'],
         provider => $windows_provider,
       }
@@ -287,7 +289,8 @@ class newrelic_infra::agent (
   } else {
     # Setup agent service
     service { 'newrelic-infra':
-      ensure  => $service_ensure,
+      ensure => $service_ensure,
+      enable => true
     }
   }
 }


### PR DESCRIPTION
I just defined an optional parameter to change the default MSI installation folder, On previous script there was a static folder for administrator user to install the MSI package which depends on the directory that is not always available on every machine, I also redirected MSI installation into the TEMP folder to ```C:\TEMP``` by default and it's will be changeable according to the developers need.

Unfortunately, there are no windows CI support for this project and I just test the script manually on windows servers.