### PR TITLE
Add Amazon Linux 2 and aarch64 tarball support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,4 @@ Use `bundle exec kitchen` to run commands.
 * Jonatan Bernal (@els-bernalj)
 * Keith Stone (@kwstone14)
 * Josh Simmonds (@j0sh3rs)
+* Michael Stathers (@mstathers)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -192,6 +192,7 @@ class newrelic_infra::agent (
           case $facts['os']['architecture'] {
             'x86_64': { $arch = 'amd64' }
             'i386': { $arch = '386' }
+            'aarch64': { $arch = 'arm64' }
             default: { $arch = facts['os']['architecture'] }
           }
           $tar_filename = "newrelic-infra_linux_${tarball_version}_${arch}.tar.gz"

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -125,8 +125,10 @@ class newrelic_infra::agent (
               }
             }
             'RedHat', 'CentOS', 'Amazon', 'OracleLinux': {
-              if ($::operatingsystem == 'Amazon') {
+              if ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '1'){
                 $repo_releasever = '6'
+              } elsif ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '2'){
+                $repo_releasever = '7'
               } else {
                 $repo_releasever = $::operatingsystemmajrelease
               }
@@ -275,7 +277,7 @@ class newrelic_infra::agent (
 
   # we use Upstart on CentOS 6 systems and derivatives, which is not the default
   if (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat')and $::operatingsystemmajrelease == '6')
-  or ($::operatingsystem == 'Amazon') {
+  or ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '1') {
     service { 'newrelic-infra':
       ensure   => $service_ensure,
       provider => 'upstart',

--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,10 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": ["2008", "2012", "2016"]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": ["1", "2"]
     }
   ],
   "requirements": [


### PR DESCRIPTION
I noticed this module would support the older rhel/centos 6 based Amazon 1, but not the newer Amazon 2. In an x86_64 install, it should be able to find the correct package now and it should also be able to start the daemon now.

I also needed to translate between the `aarch64` architecture provided by in the OS fact to `arm64` as used here - https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/