### PR TITLE
Change default windows_temp_folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Allows for the selection of a provider other than `windows` for the [Windows MSI
 A string value for the temporary folder to download and install the MSI windows installation file. Example:
 
 ```
-windows_temp_folder => 'C:/users/Administrator/Downloads'
+windows_temp_folder => 'C:/Temp'
 ```
 
 ##### `package_repo_ensure` (Optional)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -81,7 +81,7 @@ class newrelic_infra::agent (
   $custom_attributes    = {},
   $custom_configs       = {},
   $windows_provider     = 'windows',
-  $windows_temp_folder  = 'C:/users/Administrator/Downloads',
+  $windows_temp_folder  = 'C:/Windows/Temp',
   $linux_provider       = 'package_manager',
   $tarball_version      = undef
 ) {


### PR DESCRIPTION
Our Windows VMs do not have an `Administrator` user, so the default `windows_temp_folder` of `C:/users/Administrator/Downloads` could not be found and installation failed.

It's simple enough to override this setting when applying the class, but I thought it could also be good to change the default to something that might work out-of-the-box for more people. AFAIK `C:\Windows\Temp` is available on all Windows systems.