### PR TITLE
Amazon linux no longer does it this way.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -274,8 +274,7 @@ class newrelic_infra::agent (
   }
 
   # we use Upstart on CentOS 6 systems and derivatives, which is not the default
-  if (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat')and $::operatingsystemmajrelease == '6')
-  or ($::operatingsystem == 'Amazon') {
+  if (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat')and $::operatingsystemmajrelease == '6') {
     service { 'newrelic-infra':
       ensure   => $service_ensure,
       provider => 'upstart',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -126,7 +126,7 @@ class newrelic_infra::agent (
             }
             'RedHat', 'CentOS', 'Amazon', 'OracleLinux': {
               if ($::operatingsystem == 'Amazon') {
-                $repo_releasever = '6'
+                $repo_releasever = '7'
               } else {
                 $repo_releasever = $::operatingsystemmajrelease
               }


### PR DESCRIPTION
Amazon Linux no longer uses upstart for it's package management. It can support whatever is configured globally in puppet ( yum, rpm, etc.) This code caused an error on current amazon linux instances:

```
/Stage[main]/Newrelic_infra::Agent/Service[newrelic-infra]: Provider upstart is not functional on this host
```