### PR TITLE
fix: Windows package ensure value to avoid "latest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # newrelic-infra Puppet module CHANGELOG
 
+## 0.10.2 (2021-05-05)
+
+BUG FIXES:
+
+* Fixed Windows package "ensure" value to exclude 'latest'.
+
 ## 0.10.1 (2021-05-05)
 
 IMPROVEMENTS:

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -232,6 +232,12 @@ class newrelic_infra::agent (
       }
     }
     'windows': {
+      if $ensure == 'latest' {
+        $ensure_windows = 'installed'
+      } else {
+        $ensure_windows = $ensure
+      }
+
       # download the new relic infrastructure msi file
       file { 'download_newrelic_agent':
         ensure => file,
@@ -240,7 +246,7 @@ class newrelic_infra::agent (
       }
 
       package { 'newrelic-infra':
-        ensure   => $ensure,
+        ensure   => $ensure_windows,
         name     => 'New Relic Infrastructure Agent',
         source   => "${windows_temp_folder}/newrelic-infra.msi",
         require  => File['download_newrelic_agent'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_infra",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "New Relic, Inc.",
   "summary": "A Puppet module for installing New Relic Infrastructure Agent",
   "license":


### PR DESCRIPTION
Windows (MSI) provider does not have 'upgradeable' feature, so this replaces `latest` with `installed`.