### PR TITLE
Add debian 10 and centos 8 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,8 @@
             "operatingsystemrelease": [
                 "7",
                 "8",
-                "9"
+                "9",
+                "10"
             ]
         },
         {
@@ -33,7 +34,8 @@
             "operatingsystemrelease": [
                 "5",
                 "6",
-                "7"
+                "7",
+                "8"
             ]
         },
         {

--- a/metadata.json
+++ b/metadata.json
@@ -88,7 +88,7 @@
     ],
     "requirements": [{
         "name": "puppet",
-        "version_requirement": ">= 3.0.0 < 8.0.0"
+        "version_requirement": ">= 4.0.0 < 8.0.0"
     }],
     "pdk-version": "2.1.0",
     "template-url": "https://github.com/puppetlabs/pdk-templates#master",


### PR DESCRIPTION
Minimum required version of puppet has been increased due to issues with ssl connection and apt package that seem to have been resolved in puppet 4+