### PR TITLE
Enable upgrading of Windows agent versions

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -260,16 +260,18 @@ class newrelic_infra::agent (
       }
     }
     'windows': {
-      if $ensure == 'latest' {
+      if $ensure in ['present', 'latest', 'installed'] {
         $ensure_windows = 'installed'
+        $download_windows = 'newrelic-infra.msi'
       } else {
         $ensure_windows = $ensure
+        $download_windows = "newrelic-infra.${ensure}.msi"
       }
 
       # download the new relic infrastructure msi file
       remote_file { 'download_newrelic_agent':
         ensure => present,
-        path   => "${windows_temp_folder}/newrelic-infra.msi",
+        path   => "${windows_temp_folder}/${download_windows}",
         source => $windows_download_url,
         proxy  => $download_proxy
       }
@@ -277,7 +279,7 @@ class newrelic_infra::agent (
       package { 'newrelic-infra':
         ensure   => $ensure_windows,
         name     => 'New Relic Infrastructure Agent',
-        source   => "${windows_temp_folder}/newrelic-infra.msi",
+        source   => "${windows_temp_folder}/${download_windows}",
         require  => Remote_file['download_newrelic_agent'],
         provider => $windows_provider,
       }


### PR DESCRIPTION
The Windows install currently only realistically allows the installation of whatever version the upstream newrelic-infra.msi is, and doesn't allow for the possibility of upgrading the newrelic agent once it is present on a server.

This patch only uses the file name "newrelic-infra.msi" in the case that the version is set to be "installed" or "latest". For other versions, it tries to download and install a matching newrelic-infra.${ensure}.msi file and install that.

While this doesn't enable the real use of "latest" as a version, it does enable a way to pick a specific version and so ensure that upgrades of agents become possible.