### PR TITLE
Allow more recent versions of stdlib + apt modules. Fix deprecation w…

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,11 @@
     "issues_url": "https://github.com/newrelic/infrastructure-agent-puppet/issues",
     "dependencies": [{
             "name": "puppetlabs-apt",
-            "version_requirement": ">= 2.3.0 < 8.0.0"
+            "version_requirement": ">= 2.3.0 < 9.0.0"
         },
         {
             "name": "puppetlabs-stdlib",
-            "version_requirement": ">= 4.2.0 < 8.0.0"
+            "version_requirement": ">= 4.2.0 < 9.0.0"
         },
         {
             "name": "lwf-remote_file",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# This must be defined before the actual import of the helper itself
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
This makes sure the module is easier to include in existing puppet systems migrating to puppet 7.
Also fixes a small deprecation warning when/if migrating to puppet 7.