### PR TITLE
Bugfix to specified agent download on Windows

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -55,7 +55,7 @@
 #   Optional. Proxy url for tarball or msi install
 #
 # [*windows_download_url*]
-#   Optional. A string value for the download URL for MSI windows installation file.
+#   Optional. A string value for the *base* download URL for MSI windows installation file.
 #
 # [*linux_provider*]
 #   Specifies the provider to use for installing the agent. Two options are
@@ -94,7 +94,7 @@ class newrelic_infra::agent (
   $download_proxy       = undef,
   $windows_provider     = 'windows',
   $windows_temp_folder  = 'C:/Windows/Temp',
-  $windows_download_url = 'https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi',
+  $windows_download_url = 'https://download.newrelic.com/infrastructure_agent/windows',
   $linux_provider       = 'package_manager',
   $tarball_version      = undef
 ) {
@@ -272,7 +272,7 @@ class newrelic_infra::agent (
       remote_file { 'download_newrelic_agent':
         ensure => present,
         path   => "${windows_temp_folder}/${download_windows}",
-        source => $windows_download_url,
+        source => "${$windows_download_url}/${download_windows}",
         proxy  => $download_proxy
       }
 


### PR DESCRIPTION
This fixes a bug in which version of the NewRelic agent gets installed on Windows.

When a specific version of the agent is configured to be installed, the previous download_url specifically pointed at `newrelic-infra.msi` and *saved* it as a file with the name of the specific version. In most cases the specific version would be the current version, i.e. whatever `newrelic-infra.msi` was then anyway, so this bug was hidden.

If however a newer agent version had been released upstream (e.g. 1.24.2) than what was configured to be installed (e.g. 1.24.1), and a fresh server was built and ran puppet, it would download newrelic-infra.msi (i.e. 1.24.2), but save it as newrelic-infra-1.24.1.msi, and then install that misnamed package from disk.

Note that this patch can't actually downgrade an installed higher version gracefully (which appears to be a limitation of the MSI file), and this won't fix up any incorrectly named on-disk newrelic-infra-XXXX.msi files, only future ones.

To fix up existing servers and potentially downgrade them, the NewRelic agent would need to first be uninstalled, and the c:\windows\temp\newrelic-agent-*.msi deleted.