### PR TITLE
Changed out hard-coded 'amd64' reference

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -126,7 +126,7 @@ class newrelic_infra::agent (
                   location     => 'https://download.newrelic.com/infrastructure_agent/linux/apt',
                   release      => $::lsbdistcodename,
                   repos        => 'main',
-                  architecture => 'amd64',
+                  architecture => $::architecture,
                   key          => {
                       'id'     => 'A758B3FBCD43BE8D123A3476BB29EE038ECCE87C',
                       'source' => 'https://download.newrelic.com/infrastructure_agent/keys/newrelic_apt_key_current.gpg',


### PR DESCRIPTION
Instead of assuming the architecture is 'amd64', we can read it from a puppet fact ($::architecture).  This means the module installs the infra agent on 'aarch64' machines, e.g. arm64.