### PR TITLE
Fix repo uri for redhat 9

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -153,6 +153,8 @@ class newrelic_infra::agent (
                 $repo_releasever = '6'
               } elsif ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '2'){
                 $repo_releasever = '7'
+              } elsif (facts['os']['name'] == 'RedHat' and facts['os']['distro']['release']['major'] == '9') {
+                $repo_releasever = '9'
               } else {
                 $repo_releasever = $::operatingsystemmajrelease
               }


### PR DESCRIPTION
Hello,

I'm trying to use this module on redhat 9 but seeing the error bellow.

Error: Execution of '/usr/bin/dnf -d 0 -e 1 -y install check-mk-agent' returned 1: Error: Failed to download metadata for repo 'newrelic_infra-agent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
Error: /Stage[main]/Baseline::Packages/Package[check-mk-agent]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/dnf -d 0 -e 1 -y install check-mk-agent' returned 1: Error: Failed to download metadata for repo 'newrelic_infra-agent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried

Checking the repo file /etc/yum.repos.d/newrelic_infra-agent.repo the content show the uri missing the major release of the OS.

[newrelic_infra-agent]
name=New Relic Infrastructure
baseurl=https://download.newrelic.com/infrastructure_agent/linux/yum/el//x86_64
gpgcheck=True
repo_gpgcheck=True
gpgkey=https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg

I think this PR will fix the problem.

Best regards,